### PR TITLE
[codex] Fix blog bullet list formatting

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -248,6 +248,24 @@ a:hover {
   padding-left: 1.5rem;
 }
 
+.mdx-content ul {
+  list-style-type: disc;
+}
+
+.mdx-content ol {
+  list-style-type: decimal;
+}
+
+.mdx-content ul ul,
+.mdx-content ol ul {
+  list-style-type: circle;
+}
+
+.mdx-content ul ol,
+.mdx-content ol ol {
+  list-style-type: lower-alpha;
+}
+
 .mdx-content li {
   margin-bottom: 0.5rem;
   line-height: 1.7;

--- a/content/blogs/2026-03-26_The-Pin-Factory-Was-Always-The-Point.mdx
+++ b/content/blogs/2026-03-26_The-Pin-Factory-Was-Always-The-Point.mdx
@@ -33,9 +33,7 @@ At a previous company in manufacturing finance, we built an underwriting agent f
 
 We started with one agent doing all of it. In demos, it looked good. Then we tried to make it hold up across real submissions, messy email threads, inconsistent attachments, slightly different ways of saying the same thing.
 
-That was where it started to drift.
-
-Not in dramatic ways.
+That was where it started to drift in subtle ways.
 
 - Extraction would miss a field it had caught the last time because the PDF layout changed.
 - Normalization would wobble, the same data point formatted differently depending on what else came in.
@@ -43,7 +41,7 @@ Not in dramatic ways.
 
 Nothing failed loudly, which made it worse. You could not point to one broken part. You just stopped trusting the output.
 
-So we did the usual thing. Tightened the prompt. Added rules. Then added exceptions to the rules. It would improve for a stretch, then slip somewhere else.
+So we did the usual thing. Tightened the prompt and added rules. Then added exceptions to the rules. Then rules for the exceptions. It would improve for a stretch, then slip somewhere else.
 
 After a while it stopped feeling like engineering. Most of our effort was going into behavior control, not underwriting efficiency.
 


### PR DESCRIPTION
Restores explicit list marker styles for MDX unordered, ordered, and nested lists so blog bullets and numbers render after Tailwind's base reset. Includes existing copy edits in the Pin Factory post that tighten the drift/prompting section. User impact: blog posts now show readable bullet and numbered lists again without changing the MDX renderer. Validation: ran `npm run build` successfully after installing dependencies from the lockfile and clearing the stale `.next` build directory.